### PR TITLE
Special character in team code - fixed

### DIFF
--- a/cms/service/ProxyService.py
+++ b/cms/service/ProxyService.py
@@ -336,7 +336,7 @@ class ProxyService(TriggeredService):
                     users[encode_id(user.username)] = {
                         "f_name": user.first_name,
                         "l_name": user.last_name,
-                        "team": team.code if team is not None else None,
+                        "team": encode_id(team.code) if team is not None else None,
                     }
                     if team is not None:
                         teams[encode_id(team.code)] = {


### PR DESCRIPTION
If there was a special character in a team description ("AZE-1" or "AZE+1"), then the Ranking wouldn't work. 